### PR TITLE
feat: create invite link without email, allow partner signups when si…

### DIFF
--- a/apps/web/components/auth/signup-page-client.tsx
+++ b/apps/web/components/auth/signup-page-client.tsx
@@ -6,12 +6,26 @@ import { DeletedAccountToast } from '@/components/auth/deleted-account-toast';
 import { SignupGatedView } from '@/components/auth/signup-gated-view';
 import { useAuthFeatureFlags } from '@/hooks/use-auth-feature-flags';
 
+/** True when redirect points back to partner join (invite flow). */
+function isPartnerInviteRedirect(redirect: string | null): boolean {
+  if (!redirect) return false;
+  try {
+    const path = redirect.startsWith('/') ? redirect : new URL(redirect).pathname;
+    return path.includes('/partner/join');
+  } catch {
+    return redirect.includes('/partner/join');
+  }
+}
+
 export function SignupPageClient() {
   const searchParams = useSearchParams();
   const redirectTo = searchParams.get('redirect');
   const { signupGated, waitlistUrl } = useAuthFeatureFlags();
 
-  if (signupGated) {
+  const allowSignupForPartnerInvite = isPartnerInviteRedirect(redirectTo);
+  const showGated = signupGated && !allowSignupForPartnerInvite;
+
+  if (showGated) {
     return (
       <div className="bg-card rounded-lg p-8 space-y-6" data-testid="signup-page">
         <DeletedAccountToast />

--- a/apps/web/components/settings/household-tab.tsx
+++ b/apps/web/components/settings/household-tab.tsx
@@ -239,17 +239,17 @@ export function HouseholdTab({ household, isPartner = false }: HouseholdTabProps
             ) : (
             <>
             {household.partner_invite_status === 'none' && <InvitePartnerForm />}
-            {household.partner_invite_status === 'pending' && household.partner_email && (
+            {household.partner_invite_status === 'pending' && (
               <PartnerStatus
                 status="pending"
-                email={household.partner_email}
+                email={household.partner_email ?? null}
                 sentAt={household.partner_invite_sent_at ?? undefined}
               />
             )}
-            {household.partner_invite_status === 'accepted' && household.partner_email && (
+            {household.partner_invite_status === 'accepted' && (
               <PartnerStatus
                 status="accepted"
-                email={household.partner_email}
+                email={household.partner_email ?? null}
                 acceptedAt={household.partner_accepted_at ?? undefined}
                 lastLoginAt={household.partner_last_login_at}
               />

--- a/apps/web/components/settings/invite-partner-form.tsx
+++ b/apps/web/components/settings/invite-partner-form.tsx
@@ -1,14 +1,18 @@
 'use client';
 
 import { useState } from 'react';
-import { invitePartner } from '@/app/actions/partner-invite';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { invitePartner, createPartnerInviteLink } from '@/app/actions/partner-invite';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
 export function InvitePartnerForm() {
+  const router = useRouter();
   const [email, setEmail] = useState('');
   const [loading, setLoading] = useState(false);
+  const [linkLoading, setLinkLoading] = useState(false);
   const [error, setError] = useState('');
 
   async function handleSubmit(e: React.FormEvent) {
@@ -18,6 +22,7 @@ export function InvitePartnerForm() {
 
     try {
       await invitePartner(email);
+      toast.success('Invitation sent!');
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Something went wrong');
     } finally {
@@ -25,30 +30,57 @@ export function InvitePartnerForm() {
     }
   }
 
+  async function handleCreateLink() {
+    setLinkLoading(true);
+    setError('');
+    try {
+      const { url } = await createPartnerInviteLink();
+      await navigator.clipboard.writeText(url);
+      toast.success('Invite link created and copied. Share it via WhatsApp, SMS, or any app.');
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong');
+    } finally {
+      setLinkLoading(false);
+    }
+  }
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div>
-        <Label htmlFor="partner-email">Partner Email</Label>
-        <Input
-          id="partner-email"
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="partner@example.com"
-          required
-          className="mt-2"
-        />
-      </div>
+    <div className="space-y-4">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <Label htmlFor="partner-email">Partner Email</Label>
+          <Input
+            id="partner-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="partner@example.com"
+            required
+            className="mt-2"
+          />
+        </div>
 
-      {error && (
-        <p className="text-sm text-destructive" role="alert">
-          {error}
-        </p>
-      )}
+        {error && (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
 
-      <Button type="submit" disabled={loading}>
-        {loading ? 'Sending...' : 'Send Invitation'}
+        <Button type="submit" disabled={loading}>
+          {loading ? 'Sending...' : 'Send invitation email'}
+        </Button>
+      </form>
+
+      <p className="text-xs text-muted-foreground">Or create a shareable link to send yourself (e.g. WhatsApp, SMS):</p>
+      <Button
+        type="button"
+        variant="outline"
+        disabled={linkLoading}
+        onClick={handleCreateLink}
+      >
+        {linkLoading ? 'Creating...' : 'Create invite link'}
       </Button>
-    </form>
+    </div>
   );
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotbudget-v2",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "packageManager": "pnpm@8.15.4",
   "scripts": {


### PR DESCRIPTION
…gnup gated

- Add createPartnerInviteLink() and sendPartnerInviteToEmail() for link-only invites
- InvitePartnerForm: add 'Create invite link' button; copy link and refresh to pending state
- PartnerStatus: support pending with no email (link-only), optional 'Send email to' form
- Household tab: show PartnerStatus when pending (with or without email) and when accepted (even if no partner_email)
- Signup gating: show signup form when redirect is partner join so invited partners can sign up
- Bump version to 0.2.0