### PR TITLE
feat: partner invitation enhancements

### DIFF
--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -1,6 +1,8 @@
 import { createServerSupabaseClient } from '@/lib/supabase/server';
 import { NextRequest, NextResponse } from 'next/server';
 
+const REDIRECT_AFTER_AUTH_COOKIE = 'redirect_after_auth';
+
 export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url);
   const code = requestUrl.searchParams.get('code');
@@ -10,7 +12,20 @@ export async function GET(request: NextRequest) {
     await supabase.auth.exchangeCodeForSession(code);
   }
 
-  // Smart redirect based on user state (onboarding_step, current_paycycle_id)
-  // will be implemented in Phase 3
+  const redirectPath = request.cookies.get(REDIRECT_AFTER_AUTH_COOKIE)?.value;
+  if (redirectPath) {
+    try {
+      const decoded = decodeURIComponent(redirectPath);
+      if (decoded.startsWith('/')) {
+        const url = new URL(decoded, request.url);
+        const res = NextResponse.redirect(url);
+        res.cookies.set(REDIRECT_AFTER_AUTH_COOKIE, '', { path: '/', maxAge: 0 });
+        return res;
+      }
+    } catch {
+      // ignore invalid cookie
+    }
+  }
+
   return NextResponse.redirect(new URL('/dashboard', request.url));
 }

--- a/apps/web/app/partner/join/page.tsx
+++ b/apps/web/app/partner/join/page.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { createServerSupabaseClient } from '@/lib/supabase/server';
 import { acceptPartnerInvite } from '@/app/actions/partner-invite';
-import { Button } from '@/components/ui/button';
 
 interface Props {
   searchParams: Promise<{ t?: string }>;
@@ -67,49 +66,10 @@ export default async function PartnerJoinPage({ searchParams }: Props) {
 
   const joinUrl = `/partner/join?t=${encodeURIComponent(token)}`;
 
-  async function handleAccept(formData: FormData) {
-    'use server';
-    const t = formData.get('token') as string;
-    if (!t) return;
-    await acceptPartnerInvite(t);
-    redirect('/dashboard');
-  }
-
+  // Authenticated user with valid token: accept invite and go straight to dashboard (no extra screen)
   if (user) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-background" data-testid="partner-join-authenticated">
-        <div className="w-full max-w-md space-y-6 p-8">
-          <div className="text-center">
-            <h1 className="text-3xl font-bold">Welcome to PLOT!</h1>
-            <p className="mt-2 text-muted-foreground">
-              {ownerName} invited you to budget together.
-            </p>
-          </div>
-
-          <div className="rounded-lg border bg-card p-6">
-            <h2 className="font-semibold">What you&apos;ll get access to:</h2>
-            <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
-              <li>✓ View all household seeds and pots</li>
-              <li>✓ Mark your bills as paid</li>
-              <li>✓ See budget overview</li>
-              <li>✓ Collaborate on payday rituals</li>
-            </ul>
-          </div>
-
-          <form action={handleAccept} className="space-y-4">
-            <input type="hidden" name="token" value={token} />
-            <Button type="submit" className="w-full" data-testid="partner-join-accept">
-              Accept & go to dashboard →
-            </Button>
-          </form>
-
-          <p className="text-center text-xs text-muted-foreground">
-            You&apos;re signed in as {user.email}. Accepting will link your
-            account to this household.
-          </p>
-        </div>
-      </div>
-    );
+    await acceptPartnerInvite(token);
+    redirect('/dashboard');
   }
 
   return (

--- a/apps/web/components/auth/signup-page-client.tsx
+++ b/apps/web/components/auth/signup-page-client.tsx
@@ -1,10 +1,19 @@
 'use client';
 
+import { useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { AuthForm } from '@/components/auth/auth-form';
 import { DeletedAccountToast } from '@/components/auth/deleted-account-toast';
 import { SignupGatedView } from '@/components/auth/signup-gated-view';
 import { useAuthFeatureFlags } from '@/hooks/use-auth-feature-flags';
+
+const REDIRECT_AFTER_AUTH_COOKIE = 'redirect_after_auth';
+const COOKIE_MAX_AGE = 60 * 10; // 10 minutes
+
+function setRedirectAfterAuthCookie(redirectPath: string) {
+  if (typeof document === 'undefined') return;
+  document.cookie = `${REDIRECT_AFTER_AUTH_COOKIE}=${encodeURIComponent(redirectPath)}; path=/; max-age=${COOKIE_MAX_AGE}; samesite=lax`;
+}
 
 /** True when redirect points back to partner join (invite flow). */
 function isPartnerInviteRedirect(redirect: string | null): boolean {
@@ -33,6 +42,13 @@ export function SignupPageClient() {
       </div>
     );
   }
+
+  // After email confirmation Supabase sends user to auth/callback; store where to send them next
+  useEffect(() => {
+    if (redirectTo?.startsWith('/')) {
+      setRedirectAfterAuthCookie(redirectTo);
+    }
+  }, [redirectTo]);
 
   return (
     <div className="bg-card rounded-lg p-8 space-y-6" data-testid="signup-page">

--- a/apps/web/components/settings/partner-status.tsx
+++ b/apps/web/components/settings/partner-status.tsx
@@ -7,6 +7,7 @@ import {
   removePartner,
   getPartnerInviteLink,
   sendPartnerInviteToEmail,
+  removePartnerAndDeleteAccount,
 } from '@/app/actions/partner-invite';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -48,13 +49,35 @@ export function PartnerStatus({
 
   async function handleRemove() {
     if (
-      !confirm('Are you sure you want to remove your partner\'s access?')
+      !confirm('Remove partner from this household? They can be re-invited and sign in to rejoin.')
     ) {
       return;
     }
     setLoading(true);
     try {
       await removePartner();
+      toast.success('Partner removed from household');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to remove');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleRemoveAndDeleteAccount() {
+    if (
+      !confirm(
+        'Permanently remove partner and delete their account and data? This cannot be undone.'
+      )
+    ) {
+      return;
+    }
+    setLoading(true);
+    try {
+      await removePartnerAndDeleteAccount();
+      toast.success('Partner removed and account deleted');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to remove');
     } finally {
       setLoading(false);
     }
@@ -187,15 +210,27 @@ export function PartnerStatus({
           Last login: {new Date(lastLoginAt).toLocaleDateString()}
         </p>
       )}
-      <div className="mt-4">
+      <p className="mt-2 text-xs text-muted-foreground">
+        Remove from household only (they can be re-invited), or remove and delete their account.
+      </p>
+      <div className="mt-4 flex flex-wrap gap-2">
         <Button
           type="button"
           variant="outline"
           disabled={loading}
           onClick={handleRemove}
+          className="text-sm"
+        >
+          Remove from household
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={loading}
+          onClick={handleRemoveAndDeleteAccount}
           className="text-sm border-destructive text-destructive hover:bg-destructive/10"
         >
-          Remove Partner
+          Remove and delete account
         </Button>
       </div>
     </div>

--- a/apps/web/components/settings/privacy-tab.tsx
+++ b/apps/web/components/settings/privacy-tab.tsx
@@ -10,9 +10,10 @@ import { exportUserData } from '@/lib/actions/account-actions';
 
 interface PrivacyTabProps {
   userId: string;
+  isPartner?: boolean;
 }
 
-export function PrivacyTab({ userId: _userId }: PrivacyTabProps) {
+export function PrivacyTab({ userId: _userId, isPartner = false }: PrivacyTabProps) {
   const [isExporting, setIsExporting] = useState(false);
 
   const handleExport = async () => {
@@ -43,40 +44,42 @@ export function PrivacyTab({ userId: _userId }: PrivacyTabProps) {
 
   return (
     <div className="space-y-6">
-      <section className="bg-card rounded-lg border border-border p-6">
-        <h2 className="font-heading text-lg uppercase tracking-wider text-foreground mb-6">
-          Export Your Data
-        </h2>
-        <p className="text-sm text-muted-foreground mb-4">
-          Download all your budgeting data in CSV format. Includes seeds, pots,
-          repayments, and paycycle history.
-        </p>
-        <Button
-          type="button"
-          variant="secondary"
-          onClick={handleExport}
-          disabled={isExporting}
-          aria-busy={isExporting}
-        >
-          {isExporting ? (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
-          ) : (
-            <Download className="mr-2 h-4 w-4" aria-hidden />
-          )}
-          Export My Data
-        </Button>
-      </section>
+      {!isPartner && (
+        <section className="bg-card rounded-lg border border-border p-6">
+          <h2 className="font-heading text-lg uppercase tracking-wider text-foreground mb-6">
+            Export Your Data
+          </h2>
+          <p className="text-sm text-muted-foreground mb-4">
+            Download all your budgeting data in CSV format. Includes seeds, pots,
+            repayments, and paycycle history.
+          </p>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={handleExport}
+            disabled={isExporting}
+            aria-busy={isExporting}
+          >
+            {isExporting ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden />
+            ) : (
+              <Download className="mr-2 h-4 w-4" aria-hidden />
+            )}
+            Export My Data
+          </Button>
+        </section>
+      )}
 
       <section className="bg-card rounded-lg border border-border p-6">
         <h2 className="font-heading text-lg uppercase tracking-wider text-foreground mb-6">
-          Danger Zone
+          {isPartner ? 'Delete My Account' : 'Danger Zone'}
         </h2>
         <Alert variant="destructive" className="mb-6">
           <AlertTriangle className="h-4 w-4" aria-hidden />
           <AlertDescription>
-            This action cannot be undone. All your data will be permanently
-            deleted, including your household, paycycles, seeds, pots, and
-            repayments.
+            {isPartner
+              ? 'Permanently delete your account and data. You will be removed from the household. This cannot be undone.'
+              : 'This action cannot be undone. All your data will be permanently deleted, including your household, paycycles, seeds, pots, and repayments.'}
           </AlertDescription>
         </Alert>
         <DeleteAccountDialog />

--- a/apps/web/components/settings/settings-view.tsx
+++ b/apps/web/components/settings/settings-view.tsx
@@ -11,6 +11,7 @@ export interface SettingsViewProps {
     id: string;
     email: string;
     displayName: string | null;
+    avatarUrl?: string | null;
   };
   household: {
     id: string;
@@ -46,7 +47,7 @@ export function SettingsView({ user, household, isPartner = false }: SettingsVie
         <TabsList className="w-full sm:inline-flex h-auto flex-wrap gap-1 bg-muted p-1">
           <TabsTrigger value="profile">Profile</TabsTrigger>
           <TabsTrigger value="household">Household</TabsTrigger>
-          {!isPartner && <TabsTrigger value="privacy">Privacy</TabsTrigger>}
+          <TabsTrigger value="privacy">Privacy</TabsTrigger>
           {!isPartner && <TabsTrigger value="advanced">Advanced</TabsTrigger>}
         </TabsList>
         <TabsContent value="profile" className="space-y-6 mt-6">
@@ -69,11 +70,9 @@ export function SettingsView({ user, household, isPartner = false }: SettingsVie
             isPartner={isPartner}
           />
         </TabsContent>
-        {!isPartner && (
-          <TabsContent value="privacy" className="space-y-6 mt-6">
-            <PrivacyTab userId={user.id} />
-          </TabsContent>
-        )}
+        <TabsContent value="privacy" className="space-y-6 mt-6">
+          <PrivacyTab userId={user.id} isPartner={isPartner} />
+        </TabsContent>
         {!isPartner && (
           <TabsContent value="advanced" className="space-y-6 mt-6">
             <AdvancedTab

--- a/apps/web/lib/actions/auth-actions.ts
+++ b/apps/web/lib/actions/auth-actions.ts
@@ -3,6 +3,7 @@
 import { redirect } from 'next/navigation';
 import { createServerSupabaseClient } from '@/lib/supabase/server';
 import { revalidatePath } from 'next/cache';
+import { leaveHouseholdAsPartner } from '@/app/actions/partner-invite';
 
 /**
  * Signs out the current user. Caller should redirect and show toast on success.
@@ -28,9 +29,11 @@ export async function signOut() {
 }
 
 /**
- * Signs out the partner (they have an account) and redirects to login. Use when partner clicks "Leave".
+ * Partner leaves the household (unlinks from it) then signs out and redirects to login.
+ * Use when partner clicks "Leave". They can be re-invited and sign in to rejoin.
  */
 export async function leavePartnerSession() {
+  await leaveHouseholdAsPartner();
   await signOut();
   revalidatePath('/', 'layout');
   redirect('/login');

--- a/apps/web/tests/specs/partner-guest.spec.ts
+++ b/apps/web/tests/specs/partner-guest.spec.ts
@@ -59,7 +59,7 @@ test.describe('Partner invite (unauthenticated)', () => {
 });
 
 test.describe('Partner invite (authenticated)', () => {
-  test('partner with valid token sees Accept and can accept then reach dashboard', async ({
+  test('partner with valid token is taken straight to dashboard', async ({
     page,
   }) => {
     // Sign in as partner programmatically (no login UI) so we don't depend on the login form in the browser
@@ -70,19 +70,8 @@ test.describe('Partner invite (authenticated)', () => {
       waitUntil: 'domcontentloaded',
     });
 
-    await expect(page).toHaveURL(
-      (url) =>
-        url.pathname === '/partner/join' &&
-        url.searchParams.get('t') === E2E_PARTNER_INVITE_TOKEN
-    );
-
-    const partnerPage = new PartnerJoinPage(page);
-    await partnerPage.expectAuthenticatedJoin();
-    await partnerPage.clickAccept();
-
-    // After accept we should land on dashboard (owner household has paycycle from global setup).
-    // If the app sends partner to onboarding instead, accept that so the test is resilient.
-    await page.waitForURL(/\/(dashboard|onboarding)/);
+    // Invite is auto-accepted and user is redirected to dashboard (no Accept screen)
+    await page.waitForURL(/\/(dashboard|onboarding)/, { timeout: 15_000 });
     const onDashboard =
       page.getByTestId('dashboard-hero').or(page.getByTestId('dashboard-no-cycle'));
     const onOnboarding = page.getByTestId('onboarding-step-1');


### PR DESCRIPTION
- Auto-accept on /partner/join when logged in; redirect straight to dashboard
- Auth callback respects redirect_after_auth cookie (signup from partner link)
- Signup page sets cookie for post-confirmation redirect to partner join

Partner leave & remove (GDPR):
- leaveHouseholdAsPartner(): partner unlinks and can be re-invited; Leave uses it
- Owner: Remove from household (keep account) or Remove and delete account
- deleteUserAccount() supports partners (unlink then delete)
- Privacy tab for partners with Delete my account

E2E: partner guest spec expects redirect to dashboard when authenticated