### PR TITLE
fix(e2e): partner redirect and blueprint add-seed resilience

### DIFF
--- a/apps/web/tests/pages/blueprint.page.ts
+++ b/apps/web/tests/pages/blueprint.page.ts
@@ -161,8 +161,9 @@ export class BlueprintPage {
     // Force full page load so we get fresh server data (router.refresh() can be unreliable in CI)
     await this.page.goto('/dashboard/blueprint');
     await this.page.waitForURL(/\/dashboard\/blueprint/, { timeout: 15_000 });
-    // Use .first() because the same seed name can appear in multiple categories or cycles (strict mode)
-    await expect(this.seedCard(params.name).first()).toBeVisible({ timeout: 15_000 });
+    // Use .first() because the same seed name can appear in multiple categories or cycles (strict mode).
+    // Allow 20s for CI where the new seed can take a moment to appear after reload.
+    await expect(this.seedCard(params.name).first()).toBeVisible({ timeout: 20_000 });
   }
 
   async expectSeedInList(seedName: string, amount: number) {

--- a/apps/web/tests/specs/blueprint.spec.ts
+++ b/apps/web/tests/specs/blueprint.spec.ts
@@ -12,6 +12,7 @@ test.describe.serial('Blueprint - Seed Management', () => {
   });
 
   test('add a new recurring need seed', async ({ page }) => {
+    test.setTimeout(90_000); // addSeed: dialog close + reload + seed card visibility can exceed 30s in CI
     const blueprintPage = new BlueprintPage(page);
     await blueprintPage.goto();
 

--- a/apps/web/tests/specs/partner-guest.spec.ts
+++ b/apps/web/tests/specs/partner-guest.spec.ts
@@ -69,11 +69,11 @@ test.describe('Partner invite (authenticated)', () => {
     await page.context().addCookies([cookie]);
 
     await page.goto(`/partner/join?t=${encodeURIComponent(E2E_PARTNER_INVITE_TOKEN)}`, {
-      waitUntil: 'domcontentloaded',
+      waitUntil: 'load',
     });
 
     // Invite is auto-accepted and user is redirected to dashboard (no Accept screen)
-    await page.waitForURL(/\/(dashboard|onboarding)/, { timeout: 15_000 });
+    await page.waitForURL(/\/(dashboard|onboarding)/, { timeout: 30_000 });
     const onDashboard =
       page.getByTestId('dashboard-hero').or(page.getByTestId('dashboard-no-cycle'));
     const onOnboarding = page.getByTestId('onboarding-step-1');


### PR DESCRIPTION
- Partner invite (authenticated): waitUntil 'load' and 30s for redirect
- Blueprint add seed: 20s for seed card visibility, 90s test timeout