### PR TITLE
fix: profile-tab partner edit + E2E dashboard/ritual stability

### DIFF
--- a/apps/web/components/settings/profile-tab.tsx
+++ b/apps/web/components/settings/profile-tab.tsx
@@ -67,23 +67,21 @@ export function ProfileTab({
           Profile Information
         </h2>
         <form onSubmit={handleSubmit} className="space-y-6">
-          {!isPartner && (
-            <div className="space-y-2">
-              <Label htmlFor="displayName">What should we call you?</Label>
-              <Input
-                id="displayName"
-                value={displayName}
-                onChange={(e) => setDisplayName(e.target.value)}
-                placeholder="e.g. Adam"
-                maxLength={50}
-                disabled={isLoading}
-                aria-describedby="displayName-help"
-              />
-              <p id="displayName-help" className="text-sm text-muted-foreground">
-                Used for labels in the app. For couple households, both you and your partner&apos;s names appear on bills.
-              </p>
-            </div>
-          )}
+          <div className="space-y-2">
+            <Label htmlFor="displayName">What should we call you?</Label>
+            <Input
+              id="displayName"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="e.g. Adam"
+              maxLength={50}
+              disabled={isLoading}
+              aria-describedby="displayName-help"
+            />
+            <p id="displayName-help" className="text-sm text-muted-foreground">
+              Used for labels in the app. For couple households, both you and your partner&apos;s names appear on bills.
+            </p>
+          </div>
           <div className="space-y-2">
             <Label htmlFor="email">Email</Label>
             <Input

--- a/apps/web/tests/specs/dashboard.spec.ts
+++ b/apps/web/tests/specs/dashboard.spec.ts
@@ -67,7 +67,8 @@ test.describe('Dashboard and app shell', () => {
     const gotIt = page.getByRole('button', { name: 'Got it' });
     if (await gotIt.isVisible({ timeout: 2000 }).catch(() => false)) {
       await gotIt.click();
-      await page.waitForTimeout(300);
+      // Wait for modal content to be gone so overlay does not block user menu in CI
+      await page.getByText('Founding Member', { exact: false }).waitFor({ state: 'hidden', timeout: 5000 }).catch(() => {});
     }
     await page.getByTestId('user-menu-trigger').click();
     await page.getByRole('menuitem', { name: 'Log out' }).click();

--- a/apps/web/tests/specs/ritual.spec.ts
+++ b/apps/web/tests/specs/ritual.spec.ts
@@ -72,8 +72,8 @@ test.describe.serial('Blueprint - Payment tracking (current cycle)', () => {
     await expect(closeCycleButton).toBeVisible({ timeout: 20_000 });
     await closeCycleButton.click();
 
-    // Celebration modal has AnimatePresence + motion; wait for heading first, then close button (allow 15s for CI)
-    await expect(page.getByText('Ritual Complete!', { exact: false })).toBeVisible({ timeout: 15_000 });
+    // Celebration modal has AnimatePresence + motion; wait for heading first, then close button (25s in CI to match other ritual test)
+    await expect(page.getByText('Ritual Complete!', { exact: false })).toBeVisible({ timeout: process.env.CI ? 25_000 : 15_000 });
     await expect(blueprintPage.ritualCelebrationClose).toBeVisible({
       timeout: 10_000,
     });


### PR DESCRIPTION
- Profile: show display name and Save for partners (remove !isPartner guard)
- Dashboard: wait for Founding Member modal to close before user menu click
- Ritual: use 25s timeout for celebration in CI to match other test